### PR TITLE
Fix typo in create_user

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -179,16 +179,16 @@ def create_user():
         # Password Policies
         if len(password) < 8:
             log_event(f"{current_user.username} attempted to create a user with an invalid password.", "INVALID_PASSWORD", current_user.id)
-            return render_template('create_user.html', error="Password must be at least 8 characters long.", usernmame=username, role=role)
+            return render_template('create_user.html', error="Password must be at least 8 characters long.", username=username, role=role)
         if not re.search(r"\d", password):
             log_event(f"{current_user.username} attempted to create a user with an invalid password.", "INVALID_PASSWORD", current_user.id)
-            return render_template('create_user.html', error="Password must contain at least one number.", usernmame=username, role=role)
+            return render_template('create_user.html', error="Password must contain at least one number.", username=username, role=role)
         if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", password):
             log_event(f"{current_user.username} attempted to create a user with an invalid password.", "INVALID_PASSWORD", current_user.id)
-            return render_template('create_user.html', error="Password must contain at least one special character.", usernmame=username, role=role)
+            return render_template('create_user.html', error="Password must contain at least one special character.", username=username, role=role)
         if not re.search(r"[A-Z]", password):
             log_event(f"{current_user.username} attempted to create a user with an invalid password.", "INVALID_PASSWORD", current_user.id)
-            return render_template('create_user.html', error="Password must contain at least one uppercase letter.", usernmame=username, role=role)
+            return render_template('create_user.html', error="Password must contain at least one uppercase letter.", username=username, role=role)
 
         # Hash the password before storing it
         password = pwd_context.hash(password)


### PR DESCRIPTION
## Summary
- fix variable typo in `create_user` when re-rendering form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a42075f98832388ffbc193a037fc0