### PR TITLE
Add environment variable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Ensure you have Python installed. Then, install the required Python packages:
 4. **Configure the Database:**
 Set up the database using the provided SQL scripts or configuration files.
 
+### Environment Variables
+
+The application reads database credentials and the JWT secret key from the environment. The following variables are supported with their default values:
+
+| Variable | Default |
+| --- | --- |
+| `DB_USER` | `root` |
+| `DB_PASSWORD` | `root` |
+| `DB_HOST` | `localhost` |
+| `DB_NAME` | `password_manager` |
+| `DB_TYPE` | `mysql` |
+| `JWT_SECRET_KEY` | `your-256-bit-secret` |
+
 5. **Run the Application:**
 Start the application locally:
     ```bash

--- a/app.py
+++ b/app.py
@@ -42,22 +42,30 @@ def load_key():
         log_event("Encryption key file not found.", "error", 0)
         raise
 
-# First option for MySQL
-app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql://root:root@localhost/password_manager'
-# Second option for SQL Server
-# app.config['SQLALCHEMY_DATABASE_URI'] = (
-#     'mssql+pyodbc://pm_server:pwmanager@localhost/password_manager?'
-#     'driver=ODBC+Driver+17+for+SQL+Server&'
-#     'autocommit=True&'
-#     'TrustServerCertificate=yes'  # For development only
-# )
+# Configure database connection from environment variables
+db_user = os.environ.get('DB_USER', 'root')
+db_password = os.environ.get('DB_PASSWORD', 'root')
+db_host = os.environ.get('DB_HOST', 'localhost')
+db_name = os.environ.get('DB_NAME', 'password_manager')
+db_type = os.environ.get('DB_TYPE', 'mysql')
+
+if db_type.lower() == 'mssql':
+    app.config['SQLALCHEMY_DATABASE_URI'] = (
+        f"mssql+pyodbc://{db_user}:{db_password}@{db_host}/{db_name}?"
+        "driver=ODBC+Driver+17+for+SQL+Server&"
+        "autocommit=True&"
+        "TrustServerCertificate=yes"
+    )
+else:
+    app.config['SQLALCHEMY_DATABASE_URI'] = (
+        f"mysql://{db_user}:{db_password}@{db_host}/{db_name}")
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SECRET_KEY'] = os.urandom(24)
 app.config['ENCRYPTION_KEY'] = load_key()
 app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=15)
 app.config['SESSION_COOKIE_SECURE'] = True
 app.config['SESSION_COOKIE_HTTPONLY'] = True
-app.config['JWT_SECRET_KEY'] = 'your-256-bit-secret'  # Change this!
+app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'your-256-bit-secret')
 app.config['JWT_TOKEN_LOCATION'] = ['headers']  # Look for JWT in headers
 
 jwt = JWTManager(app)

--- a/refreshdb.py
+++ b/refreshdb.py
@@ -1,3 +1,12 @@
+import os
+
+# Ensure environment variables exist when running this utility script
+os.environ.setdefault('DB_USER', 'root')
+os.environ.setdefault('DB_PASSWORD', 'root')
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_NAME', 'password_manager')
+os.environ.setdefault('DB_TYPE', 'mysql')
+
 from app import app
 from models import db, User, Password
 

--- a/tests/test_api_login.py
+++ b/tests/test_api_login.py
@@ -1,5 +1,13 @@
 import os, sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Ensure environment variables expected by the application are present
+os.environ.setdefault('JWT_SECRET_KEY', 'test-secret')
+os.environ.setdefault('DB_USER', 'root')
+os.environ.setdefault('DB_PASSWORD', 'root')
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_NAME', 'password_manager')
+os.environ.setdefault('DB_TYPE', 'mysql')
 import pytest
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager
@@ -12,7 +20,7 @@ def create_test_app():
     app.config.update({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
-        'JWT_SECRET_KEY': 'test-secret'
+        'JWT_SECRET_KEY': os.environ['JWT_SECRET_KEY']
     })
     JWTManager(app)
     db.init_app(app)

--- a/viewdb.py
+++ b/viewdb.py
@@ -1,3 +1,11 @@
+import os
+
+os.environ.setdefault('DB_USER', 'root')
+os.environ.setdefault('DB_PASSWORD', 'root')
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_NAME', 'password_manager')
+os.environ.setdefault('DB_TYPE', 'mysql')
+
 from app import app
 from models import db, User, Password
 


### PR DESCRIPTION
## Summary
- load database credentials and JWT secret key from environment variables
- document new environment variable support in README
- update test suite and scripts to set defaults

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb5c68dc48323861ad1fe08f02b0e