### PR TITLE
Add audit logging for API actions

### DIFF
--- a/api_functions.py
+++ b/api_functions.py
@@ -22,7 +22,13 @@ def authenticate_and_get_token(username, password):
     db.session.commit()
 
     access_token = create_access_token(identity=str(user.id))
-    
+
+    log_event(
+        f"User {user.username} authenticated via API.",
+        "API_LOGIN",
+        user.id,
+    )
+
     return {
         "access_token": access_token,
         "user_id": user.id
@@ -92,7 +98,14 @@ def add_password_api(user_id, data):
         
         db.session.add(new_password)
         db.session.commit()
-        
+
+        user = User.query.get(user_id)
+        log_event(
+            f"User {user.username} added a password via API.",
+            "API_PASSWORD_ADD",
+            user_id,
+        )
+
         return {
             "message": "Password added successfully",
             "password_id": new_password.id
@@ -123,6 +136,13 @@ def update_password_api(user_id, password_id, data):
             password_entry.notes = data['notes']
             
         db.session.commit()
+
+        user = User.query.get(user_id)
+        log_event(
+            f"User {user.username} updated a password via API.",
+            "API_PASSWORD_UPDATE",
+            user_id,
+        )
         return {"message": "Password updated successfully"}
     except Exception as e:
         db.session.rollback()
@@ -137,6 +157,13 @@ def delete_password_api(user_id, password_id):
     try:
         db.session.delete(password_entry)
         db.session.commit()
+
+        user = User.query.get(user_id)
+        log_event(
+            f"User {user.username} deleted a password via API.",
+            "API_PASSWORD_DELETE",
+            user_id,
+        )
         return {"message": "Password deleted successfully"}
     except Exception as e:
         db.session.rollback()

--- a/tests/test_api_login.py
+++ b/tests/test_api_login.py
@@ -8,7 +8,7 @@ os.environ.setdefault('JWT_SECRET_KEY', 'test-secret')
 import pytest
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager
-from models import db, User
+from models import db, User, audit_log
 from api_functions import authenticate_and_get_token, pwd_context
 
 
@@ -63,6 +63,11 @@ def test_successful_login(client):
     data = response.get_json()
     assert 'access_token' in data
     assert data['user_id']
+    with app.app_context():
+        logs = audit_log.query.all()
+        assert len(logs) == 1
+        assert logs[0].event_type == 'API_LOGIN'
+        assert logs[0].user_id == data['user_id']
 
 
 def test_invalid_credentials(client):

--- a/tests/test_api_passwords.py
+++ b/tests/test_api_passwords.py
@@ -1,0 +1,74 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from flask import Flask
+from cryptography.fernet import Fernet
+
+from models import db, User, Password, audit_log
+from api_functions import add_password_api, update_password_api, delete_password_api, pwd_context
+
+
+def create_test_app():
+    app = Flask(__name__)
+    app.config.update({
+        'TESTING': True,
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'ENCRYPTION_KEY': Fernet.generate_key(),
+    })
+    db.init_app(app)
+    return app
+
+
+@pytest.fixture
+def app_ctx():
+    app = create_test_app()
+    with app.app_context():
+        db.create_all()
+        user = User(username='TESTUSER', password=pwd_context.hash('secret'), role='employee')
+        db.session.add(user)
+        db.session.commit()
+        yield app
+
+
+def test_add_password_logs_event(app_ctx):
+    user = User.query.filter_by(username='TESTUSER').first()
+    result = add_password_api(user.id, {
+        'service_name': 'email',
+        'username': 'me',
+        'password': 'pw'
+    })
+    assert result['message'] == 'Password added successfully'
+    log = audit_log.query.filter_by(event_type='API_PASSWORD_ADD').first()
+    assert log is not None
+    assert log.user_id == user.id
+
+
+def test_update_password_logs_event(app_ctx):
+    user = User.query.filter_by(username='TESTUSER').first()
+    add_res = add_password_api(user.id, {
+        'service_name': 'email',
+        'username': 'me',
+        'password': 'pw'
+    })
+    password_id = add_res['password_id']
+    result = update_password_api(user.id, password_id, {'password': 'new'})
+    assert result['message'] == 'Password updated successfully'
+    log = audit_log.query.filter_by(event_type='API_PASSWORD_UPDATE').first()
+    assert log is not None
+    assert log.user_id == user.id
+
+
+def test_delete_password_logs_event(app_ctx):
+    user = User.query.filter_by(username='TESTUSER').first()
+    add_res = add_password_api(user.id, {
+        'service_name': 'email',
+        'username': 'me',
+        'password': 'pw'
+    })
+    password_id = add_res['password_id']
+    result = delete_password_api(user.id, password_id)
+    assert result['message'] == 'Password deleted successfully'
+    log = audit_log.query.filter_by(event_type='API_PASSWORD_DELETE').first()
+    assert log is not None
+    assert log.user_id == user.id
+


### PR DESCRIPTION
## Summary
- log API actions in `authenticate_and_get_token`
- log add/update/delete password API actions
- test that logs are written for API login and password CRUD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688537a49b3483239b2576a782f36691