### PR TITLE
Add security headers and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,11 +91,17 @@ def apply_csp(response):
         "style-src 'self' 'unsafe-inline' https://stackpath.bootstrapcdn.com;"
     )
     return response
+
+@app.after_request
+def set_security_headers(response):
+    return apply_security_headers(response)
 def apply_security_headers(response):
     response.headers['X-Content-Type-Options'] = 'nosniff'
     response.headers['X-Frame-Options'] = 'DENY'
     response.headers['X-XSS-Protection'] = '1; mode=block'
     response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+    response.headers['Strict-Transport-Security'] = 'max-age=63072000; includeSubDomains'
+    response.headers['Session-Cookie-SameSite'] = 'Lax'
     return response
 
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,44 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from flask import Flask
+
+secret_path = os.path.join(os.path.dirname(__file__), '..', 'secret.key')
+if not os.path.exists(secret_path):
+    with open(secret_path, 'wb') as f:
+        f.write(b'testkey')
+
+from app import apply_csp, apply_security_headers
+
+
+def create_test_app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    @app.route('/')
+    def index():
+        return 'index'
+
+    app.after_request(apply_csp)
+    app.after_request(apply_security_headers)
+
+    return app
+
+
+@pytest.fixture
+def client():
+    app = create_test_app()
+    with app.test_client() as client:
+        yield client
+
+
+def test_security_headers_present(client):
+    response = client.get('/')
+    headers = response.headers
+    assert 'Content-Security-Policy' in headers
+    assert 'X-Content-Type-Options' in headers
+    assert 'X-Frame-Options' in headers
+    assert 'X-XSS-Protection' in headers
+    assert 'Referrer-Policy' in headers
+    assert headers['Strict-Transport-Security'] == 'max-age=63072000; includeSubDomains'
+    assert headers['Session-Cookie-SameSite'] == 'Lax'


### PR DESCRIPTION
## Summary
- add security headers to Flask responses
- append `apply_security_headers` after request to ensure they are set
- test that the expected headers appear in responses

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688537a3d9108323bb7ddc00052e7ba8