### PR TITLE
Implement configurable session lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Create a `.env` file in the project root or set the variables manually. The appl
 | `DB_NAME` | `password_manager` |
 | `DB_TYPE` | `mysql` |
 | `JWT_SECRET_KEY` | `your-256-bit-secret` |
+| `SESSION_TIMEOUT_MINUTES` | `15` |
 
 7. **Run the Application:**
 Start the application locally:

--- a/app.py
+++ b/app.py
@@ -64,7 +64,8 @@ else:
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SECRET_KEY'] = os.urandom(24)
 app.config['ENCRYPTION_KEY'] = load_key()
-app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=15)
+session_timeout = int(os.environ.get('SESSION_TIMEOUT_MINUTES', '15'))
+app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=session_timeout)
 app.config['SESSION_COOKIE_SECURE'] = True
 app.config['SESSION_COOKIE_HTTPONLY'] = True
 app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'your-256-bit-secret')

--- a/functions.py
+++ b/functions.py
@@ -48,6 +48,7 @@ def login():
                         session['username'] = user.username
                         session['user_id'] = user.id
                         session['role'] = user.role
+                        session.permanent = True
 
                         log_event(f"User {user.username} logged in.", "USER_LOGIN", user.id)
 

--- a/tests/test_session_lifetime.py
+++ b/tests/test_session_lifetime.py
@@ -1,0 +1,66 @@
+import os, sys
+from datetime import datetime, timedelta
+from http.cookies import SimpleCookie
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from flask import Flask
+from cryptography.fernet import Fernet
+
+from models import db, User
+from functions import login, pwd_context
+
+
+def create_test_app():
+    session_minutes = int(os.environ.get('SESSION_TIMEOUT_MINUTES', '15'))
+    app = Flask(__name__)
+    app.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'test-secret',
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'ENCRYPTION_KEY': Fernet.generate_key(),
+        'PERMANENT_SESSION_LIFETIME': timedelta(minutes=session_minutes),
+    })
+    db.init_app(app)
+
+    @app.route('/login', methods=['GET', 'POST'])
+    def login_route():
+        return login()
+
+    @app.route('/dashboard')
+    def dashboard_route():
+        return 'dashboard'
+
+    return app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    os.environ['SESSION_TIMEOUT_MINUTES'] = '20'
+    app = create_test_app()
+    with app.app_context():
+        db.create_all()
+        user = User(username='LOGUSER', password=pwd_context.hash('pw'), role='employee')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client, app
+
+
+def test_session_lifetime(client):
+    client, app = client
+    resp = client.post('/login', data={'username': 'LOGUSER', 'password': 'pw'})
+    assert resp.status_code == 302
+    assert '/dashboard' in resp.headers['Location']
+
+    with client.session_transaction() as sess:
+        assert sess.permanent is True
+
+    cookie = SimpleCookie()
+    cookie.load(resp.headers['Set-Cookie'])
+    expires_str = cookie['session']['expires']
+    expires_dt = datetime.strptime(expires_str, '%a, %d %b %Y %H:%M:%S GMT')
+    delta = expires_dt - datetime.utcnow()
+    assert abs(delta.total_seconds() - 20 * 60) < 60
+    assert app.permanent_session_lifetime == timedelta(minutes=20)


### PR DESCRIPTION
## Summary
- mark sessions as permanent on successful login
- allow configuring session lifetime with `SESSION_TIMEOUT_MINUTES`
- document new env var in README
- test session lifetime behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688537a22bac83239f858975fa9d51d7