### PR TITLE
Add password generator and complexity validation

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -9,6 +9,19 @@ import pytz
 pwd_context = CryptContext(schemes=["scrypt"], scrypt__default_rounds=14)
 est = pytz.timezone('US/Eastern')
 
+# Helper for password policy checks
+def password_meets_requirements(password: str) -> bool:
+    """Return True if the password satisfies complexity rules."""
+    if len(password) < 8:
+        return False
+    if not re.search(r"\d", password):
+        return False
+    if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", password):
+        return False
+    if not re.search(r"[A-Z]", password):
+        return False
+    return True
+
 def index():
     return render_template('index.html')
 
@@ -76,6 +89,8 @@ def dashboard():
     if 'user_id' not in session:
         return redirect(url_for('index_route'))
 
+    error_msg = request.args.get('error')
+
     key = current_app.config['ENCRYPTION_KEY']
     cipher_suite = Fernet(key)
 
@@ -96,7 +111,7 @@ def dashboard():
                 'notes': pw.notes
             })
 
-        return render_template('dashboard.html', passwords=decrypted_passwords)
+        return render_template('dashboard.html', passwords=decrypted_passwords, error=error_msg)
     else:
         return redirect(url_for('index_route'))
 
@@ -106,6 +121,7 @@ def select_password_for_edit():
         return redirect(url_for('index_route'))
 
     service_name = request.args.get('service_name')
+    error_msg = request.args.get('error')
     
     if not service_name:
         return redirect(url_for('dashboard_route'))
@@ -136,7 +152,8 @@ def select_password_for_edit():
                     'password': decrypted_password,
                     'notes': selected_password.notes
                 },
-                passwords=user_passwords
+                passwords=user_passwords,
+                error=error_msg
             )
         else:
             return redirect(url_for('dashboard_route'))
@@ -412,8 +429,10 @@ def add_password():
     # Get the current user
     current_user = User.query.filter_by(id=session['user_id']).first()
 
-    # Encrypt the password and commit it to the database
     if current_user:
+        if not password_meets_requirements(password):
+            log_event(f"User {current_user.username} attempted to add weak password.", "INVALID_PASSWORD", current_user.id)
+            return redirect(url_for('dashboard_route', error="Password does not meet complexity requirements."))
 
         encrypted_password = cipher_suite.encrypt(password.encode())
 
@@ -440,9 +459,12 @@ def update_password(service):
     password_to_update = Password.query.filter_by(id=password_id).first()
 
     if password_to_update:
+        if not password_meets_requirements(password):
+            log_event("Weak password rejected during update.", "INVALID_PASSWORD", session.get('user_id'))
+            return redirect(url_for('dashboard_route', error="Password does not meet complexity requirements."))
+
         # Update the password's fields
         password_to_update.username = username
-        password_to_update.password = password
         password_to_update.notes = notes
 
         # Encrypt the password before saving it back to the database

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -13,6 +13,21 @@ document.addEventListener('DOMContentLoaded', () => {
     if (passwordToggleButton) {
         passwordToggleButton.addEventListener('click', togglePassword);
     }
+
+    document.querySelectorAll('.password-input').forEach(input => {
+        input.addEventListener('input', () => updateStrengthFeedback(input));
+    });
+
+    const generateBtn = document.getElementById('generate-password');
+    if (generateBtn) {
+        generateBtn.addEventListener('click', () => {
+            const target = document.getElementById('new-password');
+            if (target) {
+                target.value = generatePassword(12);
+                updateStrengthFeedback(target);
+            }
+        });
+    }
 });
 
 function togglePassword() {
@@ -37,4 +52,35 @@ function togglePasswordList(passwordid) {
         passwordField.type = "password";
         passwordToggle.innerHTML = "Show Password";
     }
+}
+
+function generatePassword(length) {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+~`|}{[]:;?><,./-=';
+    let pw = '';
+    for (let i = 0; i < length; i++) {
+        pw += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return pw;
+}
+
+function checkStrength(pw) {
+    let score = 0;
+    if (pw.length >= 8) score++;
+    if (/[A-Z]/.test(pw)) score++;
+    if (/[0-9]/.test(pw)) score++;
+    if (/[!@#$%^&*(),.?":{}|<>]/.test(pw)) score++;
+    if (score <= 1) return 'Weak';
+    if (score === 2 || score === 3) return 'Moderate';
+    return 'Strong';
+}
+
+function updateStrengthFeedback(input) {
+    const feedback = document.getElementById('strength-' + input.id);
+    if (!feedback) return;
+    const result = checkStrength(input.value);
+    let color = 'red';
+    if (result === 'Moderate') color = 'orange';
+    if (result === 'Strong') color = 'green';
+    feedback.textContent = result;
+    feedback.style.color = color;
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -16,6 +16,9 @@
             <div class="card card-centered">
                 <div class="card-body text-center">
                     <h3 class="card-title">Your passwords:</h3>
+                    {% if error %}
+                        <p class="error">{{ error }}</p>
+                    {% endif %}
                     
                     <form action="{{ url_for('select_password_for_edit_route') }}" method="GET" class="mb-4">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -45,7 +48,8 @@
                                 </div>
                                 <div class="form-row">
                                     <label for="password" class="form-label">Password:</label>
-                                    <input type="password" class="form-control form-control-custom" id="password{{ selected_password.id }}" name="password" placeholder="New password" value="{{ selected_password.password }}" autocomplete="off" required>
+                                    <input type="password" class="form-control form-control-custom password-input" id="password{{ selected_password.id }}" name="password" placeholder="New password" value="{{ selected_password.password }}" autocomplete="off" required>
+                                    <small id="strength-password{{ selected_password.id }}" class="form-text"></small>
                                 </div>
                                 <div class="form-row">
                                     <label for="notes" class="form-label">Notes:</label>
@@ -71,7 +75,9 @@
                                 <input type="text" class="form-control form-control-custom" name="username" placeholder="Username" autocomplete="off" required>
                             </div>
                             <div class="form-row">
-                                <input type="text" class="form-control form-control-custom" name="password" placeholder="Password" autocomplete="off" required>
+                                <input type="text" class="form-control form-control-custom password-input" id="new-password" name="password" placeholder="Password" autocomplete="off" required>
+                                <button type="button" class="btn btn-secondary mt-2" id="generate-password">Generate</button>
+                                <small id="strength-new-password" class="form-text"></small>
                             </div>
                             <div class="form-row">
                                 <input type="text" class="form-control form-control-custom" name="notes" placeholder="Notes" autocomplete="off">

--- a/tests/test_password_complexity.py
+++ b/tests/test_password_complexity.py
@@ -1,0 +1,84 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from flask import Flask
+from cryptography.fernet import Fernet
+
+from models import db, User, Password
+from functions import add_password, update_password, dashboard, pwd_context
+
+
+def create_test_app():
+    app = Flask(__name__)
+    app.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'test-secret',
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'ENCRYPTION_KEY': Fernet.generate_key(),
+    })
+    db.init_app(app)
+
+    @app.route('/')
+    def index_route():
+        return 'index'
+
+    @app.route('/dashboard')
+    def dashboard_route():
+        return dashboard()
+
+    @app.route('/add_password', methods=['POST'])
+    def add_password_route():
+        return add_password()
+
+    @app.route('/update_password/<service>', methods=['POST'])
+    def update_password_route(service):
+        return update_password(service)
+
+    return app
+
+
+@pytest.fixture
+def client():
+    app = create_test_app()
+    with app.app_context():
+        db.create_all()
+        user = User(username='TESTUSER', password=pwd_context.hash('pw'), role='employee')
+        db.session.add(user)
+        db.session.commit()
+        cipher = Fernet(app.config['ENCRYPTION_KEY'])
+        encrypted = cipher.encrypt(b'GoodPass1!')
+        pw = Password(service_name='email', username='user', password=encrypted, notes='', user_id=user.id)
+        db.session.add(pw)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client, app
+
+
+def test_add_password_rejects_weak(client):
+    client, app = client
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['username'] = 'TESTUSER'
+        sess['role'] = 'employee'
+    resp = client.post('/add_password', data={'service':'svc','username':'u','password':'short','notes':''})
+    assert resp.status_code == 302
+    with app.app_context():
+        assert Password.query.filter_by(service_name='svc').first() is None
+
+
+def test_update_password_rejects_weak(client):
+    client, app = client
+    with app.app_context():
+        pw = Password.query.filter_by(service_name='email').first()
+        pw_id = pw.id
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['username'] = 'TESTUSER'
+        sess['role'] = 'employee'
+    resp = client.post(f'/update_password/email', data={'pw_id':pw_id,'username':'user','password':'123','notes':''})
+    assert resp.status_code == 302
+    with app.app_context():
+        pw = Password.query.get(pw_id)
+        cipher = Fernet(app.config['ENCRYPTION_KEY'])
+        decrypted = cipher.decrypt(pw.password).decode()
+        assert decrypted == 'GoodPass1!'


### PR DESCRIPTION
## Summary
- generate client-side passwords and show strength feedback
- enforce complexity checks when adding or updating passwords
- surface error messages on dashboard
- test password complexity handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688537a193388323a471db87b2fbaeaa