### PR TITLE
Implement password sharing

### DIFF
--- a/SQL/setup_mysql.sql
+++ b/SQL/setup_mysql.sql
@@ -23,6 +23,14 @@ CREATE TABLE IF NOT EXISTS password (
     INDEX idx_user_id (user_id)
 );
 
+CREATE TABLE IF NOT EXISTS password_user (
+    password_id INT NOT NULL,
+    user_id INT NOT NULL,
+    PRIMARY KEY (password_id, user_id),
+    FOREIGN KEY (password_id) REFERENCES password(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS audit_log (
     id INT AUTO_INCREMENT PRIMARY KEY,
     event_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/SQL/setup_sqlserver.sql
+++ b/SQL/setup_sqlserver.sql
@@ -119,6 +119,24 @@ BEGIN
 END
 GO
 
+-- Association table for shared passwords
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'password_user')
+BEGIN
+    CREATE TABLE password_user (
+        password_id INT NOT NULL,
+        user_id INT NOT NULL,
+        PRIMARY KEY (password_id, user_id),
+        FOREIGN KEY (password_id) REFERENCES password(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES [user](id) ON DELETE CASCADE
+    )
+    PRINT 'Table password_user created successfully.'
+END
+ELSE
+BEGIN
+    PRINT 'Table password_user already exists.'
+END
+GO
+
 -- Audit log table
 IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'audit_log')
 BEGIN

--- a/refreshdb.py
+++ b/refreshdb.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from app import app
-from models import db, User, Password
+from models import db, User, Password, password_user
 
 # Used to delete all user and password data from the database
 # This is useful for testing purposes to refresh the database
@@ -13,6 +13,7 @@ from models import db, User, Password
 
 with app.app_context():
     try:
+        db.session.execute(password_user.delete())
         db.session.query(User).delete()
         db.session.query(Password).delete()
         db.session.commit()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -51,6 +51,14 @@
                                     <label for="notes" class="form-label">Notes:</label>
                                     <input type="text" class="form-control form-control-custom" name="notes" placeholder="Notes" value="{{ selected_password.notes }}" autocomplete="off">
                                 </div>
+                                <div class="form-row">
+                                    <label for="shared_users" class="form-label">Share with:</label>
+                                    <select class="form-select form-control-custom" name="shared_users" multiple>
+                                        {% for user in all_users %}
+                                            <option value="{{ user.id }}" {% if user.id in selected_password.shared_ids %}selected{% endif %}>{{ user.username }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
                                 <div class="mt-4">
                                     <button type="submit" class="btn btn-primary mx-2">Update</button>
                                     <button type="button" class="btn btn-secondary mx-2" id="toggle-password-{{ selected_password.id }}">Show Password</button>
@@ -75,6 +83,14 @@
                             </div>
                             <div class="form-row">
                                 <input type="text" class="form-control form-control-custom" name="notes" placeholder="Notes" autocomplete="off">
+                            </div>
+                            <div class="form-row">
+                                <label for="shared_users" class="form-label">Share with:</label>
+                                <select class="form-select form-control-custom" name="shared_users" multiple>
+                                    {% for user in all_users %}
+                                        <option value="{{ user.id }}">{{ user.username }}</option>
+                                    {% endfor %}
+                                </select>
                             </div>
                             <button type="submit" class="btn btn-primary mt-3">Add Password</button>
                         </form>


### PR DESCRIPTION
## Summary
- create `password_user` association for many-to-many relationship
- show shared passwords on dashboard and API
- manage shared users when adding or updating passwords
- update SQL setup and refresh scripts for new table
- add multi-select UI for sharing passwords
- test dashboard/API behavior with shared passwords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853923647c83239569799ab80a3a36