### PR TITLE
Add account lock feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for, session, jsonify, send_from_directory
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
-from functions import index, login, dashboard, select_password_for_edit, logout, create_user, view_users, select_user_for_edit, update_user, delete_user, unlock_account, add_password, update_password, delete_password, log_event, audit_log_viewer, get_audit_logs
+from functions import index, login, dashboard, select_password_for_edit, logout, create_user, view_users, select_user_for_edit, update_user, delete_user, unlock_account, lock_account, add_password, update_password, delete_password, log_event, audit_log_viewer, get_audit_logs
 from api_functions import get_dashboard_data, authenticate_and_get_token, revoke_token, add_password_api, update_password_api, delete_password_api
 from models import db, User, Password, TokenBlacklist
 import os
@@ -162,6 +162,10 @@ def delete_user_route(user_id):
 @app.route('/unlock_account/<user_id>', methods=['POST'])
 def unlock_account_route(user_id):
     return unlock_account(user_id)
+
+@app.route('/lock_account/<user_id>', methods=['POST'])
+def lock_account_route(user_id):
+    return lock_account(user_id)
 
 @app.route('/add_password', methods=['POST'])
 def add_password_route():

--- a/templates/view_users.html
+++ b/templates/view_users.html
@@ -73,6 +73,11 @@
                             <input type="hidden" name="user_id" value="{{ selected_user.id }}">
                             <button type="submit" class="btn btn-warning">Unlock Account</button>
                         </form>
+                        <form action="{{ url_for('lock_account_route', user_id=selected_user.id) }}" method="post">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="user_id" value="{{ selected_user.id }}">
+                            <button type="submit" class="btn btn-warning">Lock Account</button>
+                        </form>
                     {% endif %}
                 {% endif %}
 

--- a/tests/test_lock_account.py
+++ b/tests/test_lock_account.py
@@ -1,0 +1,62 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from flask import Flask
+from cryptography.fernet import Fernet
+
+from models import db, User
+from functions import lock_account, pwd_context
+
+
+def create_test_app():
+    app = Flask(__name__)
+    app.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'test-secret',
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'ENCRYPTION_KEY': Fernet.generate_key(),
+    })
+    db.init_app(app)
+
+    @app.route('/lock_account/<user_id>', methods=['POST'])
+    def lock_account_route(user_id):
+        return lock_account(user_id)
+
+    @app.route('/')
+    def index_route():
+        return 'index'
+
+    return app
+
+
+@pytest.fixture
+def client():
+    app = create_test_app()
+    with app.app_context():
+        db.create_all()
+        admin = User(username='ADMIN', password=pwd_context.hash('pw'), role='admin')
+        user = User(username='EMP', password=pwd_context.hash('pw'), role='employee')
+        db.session.add_all([admin, user])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client, app
+
+
+def test_admin_can_lock_account(client, monkeypatch):
+    client, app = client
+
+    def fake_render(template, **context):
+        return 'rendered'
+
+    monkeypatch.setattr('functions.render_template', fake_render)
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['username'] = 'ADMIN'
+        sess['role'] = 'admin'
+    resp = client.post('/lock_account/2')
+    assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.get(2)
+        assert user.failed_login_attempts > 3
+


### PR DESCRIPTION
## Summary
- implement lock_account to mirror unlock_account
- expose /lock_account route
- add Lock Account button in user management page
- test locking accounts via new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854113e70883239febd4f4c3afff9c