### PR TITLE
Implement user search for sharing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for, session, jsonify, send_from_directory
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
-from functions import index, login, dashboard, select_password_for_edit, logout, create_user, view_users, select_user_for_edit, update_user, delete_user, unlock_account, lock_account, add_password, update_password, delete_password, log_event, audit_log_viewer, get_audit_logs
+from functions import index, login, dashboard, select_password_for_edit, logout, create_user, view_users, select_user_for_edit, update_user, delete_user, unlock_account, lock_account, add_password, update_password, delete_password, log_event, audit_log_viewer, get_audit_logs, search_user
 from api_functions import get_dashboard_data, authenticate_and_get_token, revoke_token, add_password_api, update_password_api, delete_password_api
 from models import db, User, Password, TokenBlacklist
 import os
@@ -166,6 +166,10 @@ def unlock_account_route(user_id):
 @app.route('/lock_account/<user_id>', methods=['POST'])
 def lock_account_route(user_id):
     return lock_account(user_id)
+
+@app.route('/search_user')
+def search_user_route():
+    return search_user()
 
 @app.route('/add_password', methods=['POST'])
 def add_password_route():

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -28,6 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    setupUserSearch('add');
+    setupUserSearch('update');
 });
 
 function togglePassword() {
@@ -109,4 +112,51 @@ function updateStrengthFeedback(input) {
 // Export for Node.js testing
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = { generatePassword };
+}
+
+function setupUserSearch(prefix) {
+    const searchBtn = document.getElementById(`search-button-${prefix}`);
+    const searchInput = document.getElementById(`search-user-${prefix}`);
+    const resultDiv = document.getElementById(`search-result-${prefix}`);
+    const list = document.getElementById(`share-list-${prefix}`);
+
+    if (!searchBtn || !searchInput || !resultDiv || !list) return;
+
+    searchBtn.addEventListener('click', () => {
+        const username = searchInput.value.trim().toUpperCase();
+        if (!username) return;
+        fetch(`/search_user?username=${encodeURIComponent(username)}`)
+            .then(resp => resp.json())
+            .then(data => {
+                if (data.found) {
+                    resultDiv.textContent = 'User found';
+                    if (!list.querySelector(`li[data-id="${data.id}"]`)) {
+                        const li = document.createElement('li');
+                        li.dataset.id = data.id;
+                        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+                        li.textContent = data.username;
+                        const removeBtn = document.createElement('button');
+                        removeBtn.type = 'button';
+                        removeBtn.className = 'btn btn-sm btn-danger remove-user';
+                        removeBtn.textContent = 'Remove';
+                        removeBtn.addEventListener('click', () => li.remove());
+                        const hidden = document.createElement('input');
+                        hidden.type = 'hidden';
+                        hidden.name = 'shared_users';
+                        hidden.value = data.id;
+                        li.appendChild(removeBtn);
+                        li.appendChild(hidden);
+                        list.appendChild(li);
+                    }
+                } else {
+                    resultDiv.textContent = 'User not found';
+                }
+            });
+    });
+
+    list.addEventListener('click', (e) => {
+        if (e.target.classList.contains('remove-user')) {
+            e.target.closest('li').remove();
+        }
+    });
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -57,12 +57,21 @@
                                     <input type="text" class="form-control form-control-custom" name="notes" placeholder="Notes" value="{{ selected_password.notes }}" autocomplete="off">
                                 </div>
                                 <div class="form-row">
-                                    <label for="shared_users" class="form-label">Share with:</label>
-                                    <select class="form-select form-control-custom" name="shared_users" multiple>
-                                        {% for user in all_users %}
-                                            <option value="{{ user.id }}" {% if user.id in selected_password.shared_ids %}selected{% endif %}>{{ user.username }}</option>
+                                    <label for="search-user-update" class="form-label">Share with:</label>
+                                    <input type="text" id="search-user-update" class="form-control form-control-custom" placeholder="Enter username">
+                                    <button type="button" id="search-button-update" class="btn btn-secondary mt-2">Search</button>
+                                    <div id="search-result-update" class="mt-1"></div>
+                                    <ul id="share-list-update" class="list-group mt-2">
+                                        {% for user in selected_password.shared_users %}
+                                            <li data-id="{{ user.id }}" class="list-group-item d-flex justify-content-between align-items-center">
+                                                {{ user.username }}
+                                                {% if session.user_id == selected_password.owner_id %}
+                                                <button type="button" class="btn btn-sm btn-danger remove-user">Remove</button>
+                                                {% endif %}
+                                                <input type="hidden" name="shared_users" value="{{ user.id }}">
+                                            </li>
                                         {% endfor %}
-                                    </select>
+                                    </ul>
                                 </div>
                                 <div class="mt-4">
                                     <button type="submit" class="btn btn-primary mx-2">Update</button>
@@ -92,12 +101,11 @@
                                 <input type="text" class="form-control form-control-custom" name="notes" placeholder="Notes" autocomplete="off">
                             </div>
                             <div class="form-row">
-                                <label for="shared_users" class="form-label">Share with:</label>
-                                <select class="form-select form-control-custom" name="shared_users" multiple>
-                                    {% for user in all_users %}
-                                        <option value="{{ user.id }}">{{ user.username }}</option>
-                                    {% endfor %}
-                                </select>
+                                <label for="search-user-add" class="form-label">Share with:</label>
+                                <input type="text" id="search-user-add" class="form-control form-control-custom" placeholder="Enter username">
+                                <button type="button" id="search-button-add" class="btn btn-secondary mt-2">Search</button>
+                                <div id="search-result-add" class="mt-1"></div>
+                                <ul id="share-list-add" class="list-group mt-2"></ul>
                             </div>
                             <button type="submit" class="btn btn-primary mt-3">Add Password</button>
                         </form>


### PR DESCRIPTION
## Summary
- replace username dropdowns with search fields
- support selecting multiple users to share passwords with
- add `/search_user` endpoint
- update add/update password logic
- enhance JS with helper for searching users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885454dcdd08323916467896b4b7780